### PR TITLE
[BUILD] Workaround for build fail

### DIFF
--- a/eclipse/build.gradle.kts
+++ b/eclipse/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation(project(":saros.core"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1138
+    implementation("org.eclipse.platform:org.eclipse.e4.core.di:1.7.600")
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")

--- a/stf/build.gradle.kts
+++ b/stf/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     compile(project(":saros.eclipse"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1138
+    implementation("org.eclipse.platform:org.eclipse.e4.core.di:1.7.600")
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")


### PR DESCRIPTION
caused by the bundle `org.eclipse.platform:org.eclipse.e4.core.di:1.7.700`
requiring `javax.annotation:javax.annotation-api:[1.3.5,2.0.0)` which
does not seem to exist (on maven central).

This workaround just uses the previous version 1.7.600 of
org.eclipse.e4.core.di which does not have the problematic dependency.

Related issue: https://github.com/saros-project/saros/issues/1138

### Your checklist for this pull request

Please, check that:
- [ ] all commits comply with our [commit message guidelines](https://www.saros-project.org/contribute/guidelines.html#commit-message)
- [ ] your code complies with the google java format (see [here](https://www.saros-project.org/contribute/development-environment.html) for details)
- [ ] all unit tests are still successful

### Description
Please describe your pull request.

Thank you!
